### PR TITLE
Fix wrong Debit/Credit message when title has a D in it

### DIFF
--- a/src/Kmt/parser/banking/mt940/engine.php
+++ b/src/Kmt/parser/banking/mt940/engine.php
@@ -257,7 +257,7 @@ class Engine_mt940_banking_parser {
 	 */
 	function _parseTransactionDebitCredit() {
 		$results = array();
-		if (preg_match('/^:61:.*([CD])/i', $this->getCurrentTransactionData(), $results)
+		if (preg_match('/^:61:.*([CD])([\d,\.]+)N/i', $this->getCurrentTransactionData(), $results)
 				&& !empty($results[1])) {
 			return $this->_sanitizeDebitCredit($results[1]);
 		}


### PR DESCRIPTION
Copy/Paste part of the regex of _parseTransactionPrice();

The problem occurs where the name contains a D. Not sure if this is the best way to solve it.
