### PR TITLE
Some fix for Sparkasse for parsing the transaction price and transaction debit/credit

### DIFF
--- a/src/Parser/Banking/Mt940/Engine/Spk.php
+++ b/src/Parser/Banking/Mt940/Engine/Spk.php
@@ -72,6 +72,38 @@ class Spk extends Engine
     }
 
     /**
+     * Overloaded: Sparkasse can have the 3rd character of the currencyname after the C/D
+     * @inheritdoc
+     */
+    protected function parseTransactionPrice()
+    {
+        $results = array();
+        if (preg_match('/^:61:.*[CD].?([\d,\.]+)N/i', $this->getCurrentTransactionData(), $results)
+            && !empty($results[1])
+        ) {
+            return $this->sanitizePrice($results[1]);
+        }
+
+        return 0;
+    }
+
+    /**
+     * Overloaded: Sparkasse can have the 3rd character of the currencyname after the C/D and an "R" for cancellation befor the C/D
+     * @inheritdoc
+     */
+    protected function parseTransactionDebitCredit()
+    {
+        $results = array();
+        if (preg_match('/^:61:\d+R?([CD]).?\d+/', $this->getCurrentTransactionData(), $results)
+            && !empty($results[1])
+        ) {
+            return $this->sanitizeDebitCredit($results[1]);
+        }
+
+        return '';
+    }
+
+    /**
      * Overloaded: Sparkasse does not have a header line
      * @inheritdoc
      */


### PR DESCRIPTION
According to the german docs of MT940 the :61: line can have some differences wich prevents some of the statements i got to be parsed:

1. Credit/Debit can be C or D for normal transactions, and RC and RD for cancellations
2. After the C/D/RC/RD there is an optional 1 character that contains the 3rd letter of the currency name (ISO code)

(Docs at https://www.sparkasse-nuernberg.de/pdf/content/sfirm/mt940-satz.pdf?IFLBSERVERID=IF@@053@@IF)

This pull should fix this two issues. Would be nice to get it to an update/new version fast because i would need it in composer for a project to work.

Greeting Sven