### PR TITLE
Match spk to german bankcodes in the :25: live so that the parser still works if there is no STARTUMS

### DIFF
--- a/src/Parser/Banking/Mt940/Engine.php
+++ b/src/Parser/Banking/Mt940/Engine.php
@@ -43,6 +43,7 @@ abstract class Engine
     {
         $firstline = strtok($string, "\r\n\t");
         $secondline = strtok("\r\n\t");
+        $thirdline = strtok("\r\n\t");
 
         if (strpos($firstline, 'ABNA') !== false) {
             return new Engine\Abn;
@@ -57,7 +58,9 @@ abstract class Engine
         }
 
         if (strpos($firstline, ':20:STARTUMS') !== false
-            || $firstline === "-" && $secondline === ':20:STARTUMS') {
+            || $firstline === "-" && $secondline === ':20:STARTUMS'
+            || preg_match('/:25:([1-8][0-9]{2}[0-9]{5})\/\d*/i', $secondline)
+            || $firstline === "-" &&  preg_match('/:25:([1-8][0-9]{2}[0-9]{5})\/\d*/i', $thirdline)) {
             return new Engine\Spk;
         }
 


### PR DESCRIPTION
We just got the problem that some German banks, that use the same pattern of file as SPK just happens to have no kind of identifyer (like that STARTUMS) to find out that they are german banks.
Since most banks seems to use the old Bank Code + Account Number in the :25: field i changed it so that the :25: code is matched on german bank codes to fix the detecting of the bank.

I hope you can verify this fast and get me a new version fast since some of our customers are not able to upload their bank sheets at the moment.

Greetings Sven