### PR TITLE
Fix missing currency letter to cause the first number of the transaction to be cut of

### DIFF
--- a/src/Parser/Banking/Mt940/Engine/Spk.php
+++ b/src/Parser/Banking/Mt940/Engine/Spk.php
@@ -73,12 +73,13 @@ class Spk extends Engine
 
     /**
      * Overloaded: Sparkasse can have the 3rd character of the currencyname after the C/D
+     * currency codes last letter is always a letter http://www.xe.com/iso4217.php
      * @inheritdoc
      */
     protected function parseTransactionPrice()
     {
         $results = [];
-        if (preg_match('/^:61:.*[CD].?([\d,\.]+)N/i', $this->getCurrentTransactionData(), $results)
+        if (preg_match('/^:61:.*[CD][a-zA-Z]?([\d,\.]+)N/i', $this->getCurrentTransactionData(), $results)
             && !empty($results[1])
         ) {
             return $this->sanitizePrice($results[1]);


### PR DESCRIPTION
(Currencys always have a letter at the 3rd letter of the currency code (http://www.xe.com/iso4217.php))

Bug was caused by my last fix #14 since i didnt pay Attantion that if the currency is missing the first number for the transaction will be cut off.
Since the currency ISO's 3rd character is always an Letter i check for [a-zA-Z] now instad of anything.