### PR TITLE
Start end timestamps for statements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,23 +1,29 @@
 {
   "name": "kingsquare/php-mt940",
   "description": "Simple MT940 parser in PHP",
-  "keywords": ["mt940", "parsing"],
+  "keywords": [
+    "mt940",
+    "parsing"
+  ],
   "homepage": "https://github.com/fruitl00p/php-mt940",
   "type": "library",
   "license": "MIT",
   "authors": [
-	{ "name": "Robin Speekenbrink", "email": "robin@kingsquare.nl" }
+    {
+      "name": "Robin Speekenbrink",
+      "email": "robin@kingsquare.nl"
+    }
   ],
   "require": {
-	"php": ">=5.5"
+    "php": ">=5.5"
   },
   "require-dev": {
-	"phpunit/phpunit": "4.4.*",
+    "phpunit/phpunit": "4.4.*",
     "codeclimate/php-test-reporter": "dev-master"
   },
   "autoload": {
     "psr-4": {
-      "Kingsquare\\" : "src/"
+      "Kingsquare\\": "src/"
     }
   }
 }

--- a/src/Banking/Statement.php
+++ b/src/Banking/Statement.php
@@ -197,9 +197,6 @@ class Statement implements \JsonSerializable
      */
     public function getDeltaPrice()
     {
-        if (function_exists('bcmul')) {
-            return bcsub($this->getStartPrice(), $this->getEndPrice());
-        }
         return ($this->getStartPrice() - $this->getEndPrice());
     }
 }

--- a/src/Banking/Statement.php
+++ b/src/Banking/Statement.php
@@ -16,6 +16,8 @@ class Statement implements \JsonSerializable
     private $startPrice = 0.0;
     private $endPrice = 0.0;
     private $timestamp = 0;
+    private $startTimestamp = 0;
+    private $endTimestamp = 0;
     private $number = '';
 
     /**
@@ -31,7 +33,7 @@ class Statement implements \JsonSerializable
      */
     public function setBank($var)
     {
-        $this->bank = (string) $var;
+        $this->bank = (string)$var;
     }
 
     /**
@@ -39,7 +41,7 @@ class Statement implements \JsonSerializable
      */
     public function setAccount($var)
     {
-        $this->account = (string) $var;
+        $this->account = (string)$var;
     }
 
     /**
@@ -47,7 +49,7 @@ class Statement implements \JsonSerializable
      */
     public function setTransactions($transactions)
     {
-        $this->transactions = (array) $transactions;
+        $this->transactions = (array)$transactions;
     }
 
     /**
@@ -55,7 +57,7 @@ class Statement implements \JsonSerializable
      */
     public function setStartPrice($var)
     {
-        $this->startPrice = (float) $var;
+        $this->startPrice = (float)$var;
     }
 
     /**
@@ -63,15 +65,36 @@ class Statement implements \JsonSerializable
      */
     public function setEndPrice($var)
     {
-        $this->endPrice = (float) $var;
+        $this->endPrice = (float)$var;
     }
 
     /**
+     * @deprecated
      * @param int $var
      */
     public function setTimestamp($var)
     {
-        $this->timestamp = (int) $var;
+        trigger_error('Deprecated in favor of splitting the start and end timestamps for a statement. ' .
+                'Please use setStartTimestamp($format) or setEndTimestamp($format) instead. ' .
+                'setTimestamp is now setStartTimestamp', E_USER_DEPRECATED);
+        $this->timestamp = (int)$var;
+    }
+
+
+    /**
+     * @param $var
+     */
+    public function setStartTimestamp($var)
+    {
+        $this->startTimestamp = (int)$var;
+    }
+
+    /**
+     * @param $var
+     */
+    public function setEndTimestamp($var)
+    {
+        $this->endTimestamp = (int)$var;
     }
 
     /**
@@ -79,7 +102,7 @@ class Statement implements \JsonSerializable
      */
     public function setNumber($var)
     {
-        $this->number = (string) $var;
+        $this->number = (string)$var;
     }
 
     /**
@@ -124,12 +147,33 @@ class Statement implements \JsonSerializable
 
     /**
      * @param string $format
-     *
+     * @deprecated This method will be removed in favor of getStartTimestamp / getEndTimestamp this is slated for removal in next major
      * @return string
      */
     public function getTimestamp($format = 'U')
     {
-        return date($format, $this->timestamp);
+        trigger_error('Deprecated in favor of splitting the start and end timestamps for a statement. ' .
+                'Please use setStartTimestamp($format) or setEndTimestamp($format) instead. ' .
+                'getTimestamp is now getStartTimestamp', E_USER_DEPRECATED);
+        return $this->getStartTimestamp($format);
+    }
+
+    /**
+     * @param string $format
+     * @return bool|string
+     */
+    public function getStartTimestamp($format = 'U')
+    {
+        return date($format, $this->startTimestamp);
+    }
+
+    /**
+     * @param string $format
+     * @return bool|string
+     */
+    public function getEndTimestamp($format = 'U')
+    {
+        return date($format, $this->endTimestamp);
     }
 
     /**
@@ -153,6 +197,9 @@ class Statement implements \JsonSerializable
      */
     public function getDeltaPrice()
     {
+        if (function_exists('bcmul')) {
+            return bcsub($this->getStartPrice(), $this->getEndPrice());
+        }
         return ($this->getStartPrice() - $this->getEndPrice());
     }
 }

--- a/src/Banking/Transaction.php
+++ b/src/Banking/Transaction.php
@@ -35,7 +35,7 @@ class Transaction implements \JsonSerializable
      */
     public function setAccount($var)
     {
-        $this->account = (string) $var;
+        $this->account = (string)$var;
     }
 
     /**
@@ -43,7 +43,7 @@ class Transaction implements \JsonSerializable
      */
     public function setAccountName($var)
     {
-        $this->accountName = (string) $var;
+        $this->accountName = (string)$var;
     }
 
     /**
@@ -51,7 +51,7 @@ class Transaction implements \JsonSerializable
      */
     public function setPrice($var)
     {
-        $this->price = (float) $var;
+        $this->price = (float)$var;
     }
 
     /**
@@ -59,7 +59,7 @@ class Transaction implements \JsonSerializable
      */
     public function setDebitCredit($var)
     {
-        $this->debitcredit = (string) $var;
+        $this->debitcredit = (string)$var;
     }
 
     /**
@@ -67,7 +67,7 @@ class Transaction implements \JsonSerializable
      */
     public function setDescription($var)
     {
-        $this->description = (string) $var;
+        $this->description = (string)$var;
     }
 
     /**
@@ -75,7 +75,7 @@ class Transaction implements \JsonSerializable
      */
     public function setValueTimestamp($var)
     {
-        $this->valueTimestamp = (int) $var;
+        $this->valueTimestamp = (int)$var;
     }
 
     /**
@@ -83,7 +83,7 @@ class Transaction implements \JsonSerializable
      */
     public function setEntryTimestamp($var)
     {
-        $this->entryTimestamp = (int) $var;
+        $this->entryTimestamp = (int)$var;
     }
 
     /**
@@ -91,7 +91,7 @@ class Transaction implements \JsonSerializable
      */
     public function setTransactionCode($var)
     {
-        $this->transactionCode = (string) $var;
+        $this->transactionCode = (string)$var;
     }
 
     // getters

--- a/src/Parser/Banking/Mt940/Engine.php
+++ b/src/Parser/Banking/Mt940/Engine.php
@@ -397,14 +397,7 @@ abstract class Engine
      */
     protected function parseTransactionEntryTimestamp()
     {
-        $results = [];
-        if (preg_match('/^:61:(\d{6})/', $this->getCurrentTransactionData(), $results)
-                && !empty($results[1])
-        ) {
-            return $this->sanitizeTimestamp($results[1], 'ymd');
-        }
-
-        return 0;
+        return $this->parseTransactionTimestamp('61');
     }
 
     /**
@@ -413,8 +406,12 @@ abstract class Engine
      */
     protected function parseTransactionValueTimestamp()
     {
+        return $this->parseTransactionTimestamp('61');
+    }
+
+    protected function parseTransactionTimestamp($key) {
         $results = [];
-        if (preg_match('/^:61:(\d{6})/', $this->getCurrentTransactionData(), $results)
+        if (preg_match('/^:'.$key.':(\d{6})/', $this->getCurrentTransactionData(), $results)
                 && !empty($results[1])
         ) {
             return $this->sanitizeTimestamp($results[1], 'ymd');

--- a/src/Parser/Banking/Mt940/Engine/Rabo.php
+++ b/src/Parser/Banking/Mt940/Engine/Rabo.php
@@ -34,7 +34,8 @@ class Rabo extends Engine
         }
 
         if (preg_match('/^:61:.{26}(.{16})/im', $this->getCurrentTransactionData(), $results)
-                && !empty($results[1])) {
+                && !empty($results[1])
+        ) {
             return $this->sanitizeAccount($results[1]);
         }
 

--- a/src/Parser/Banking/Mt940/Engine/Spk.php
+++ b/src/Parser/Banking/Mt940/Engine/Spk.php
@@ -29,30 +29,25 @@ class Spk extends Engine
      */
     protected function parseStatementStartPrice()
     {
-        $results = [];
-        if (preg_match('/:60[FM]:.*EUR([\d,\.]+)*/', $this->getCurrentStatementData(), $results)
-                && !empty($results[1])
-        ) {
-            return $this->sanitizePrice($results[1]);
-        }
-
-        return '';
+        return parent::parseStatementPrice('60[FM]');
     }
 
     /**
      * Overloaded: Sparkasse uses 60M and 60F
      * @inheritdoc
      */
-    protected function parseStatementTimestamp()
+    protected function parseStatementStartTimestamp()
     {
-        $results = [];
-        if (preg_match('/:60[FM]:[C|D](\d{6})*/', $this->getCurrentStatementData(), $results)
-                && !empty($results[1])
-        ) {
-            return $this->sanitizeTimestamp($results[1], 'ymd');
-        }
+        return parent::parseTimestampFromStatement('60[FM]');
+    }
 
-        return 0;
+    /**
+     * Overloaded: Sparkasse uses 60M and 60F
+     * @inheritdoc
+     */
+    protected function parseStatementEndTimestamp()
+    {
+        return parent::parseTimestampFromStatement('60[FM]');
     }
 
     /**
@@ -61,14 +56,7 @@ class Spk extends Engine
      */
     protected function parseStatementEndPrice()
     {
-        $results = [];
-        if (preg_match('/:62[FM]:.*EUR([\d,\.]+)*/', $this->getCurrentStatementData(), $results)
-                && !empty($results[1])
-        ) {
-            return $this->sanitizePrice($results[1]);
-        }
-
-        return '';
+        return parent::parseStatementPrice('62[FM]');
     }
 
     /**
@@ -80,7 +68,7 @@ class Spk extends Engine
     {
         $results = [];
         if (preg_match('/^:61:.*[CD][a-zA-Z]?([\d,\.]+)N/i', $this->getCurrentTransactionData(), $results)
-            && !empty($results[1])
+                && !empty($results[1])
         ) {
             return $this->sanitizePrice($results[1]);
         }
@@ -96,7 +84,7 @@ class Spk extends Engine
     {
         $results = [];
         if (preg_match('/^:61:\d+R?([CD]).?\d+/', $this->getCurrentTransactionData(), $results)
-            && !empty($results[1])
+                && !empty($results[1])
         ) {
             return $this->sanitizeDebitCredit($results[1]);
         }

--- a/src/Parser/Banking/Mt940/Engine/Triodos.php
+++ b/src/Parser/Banking/Mt940/Engine/Triodos.php
@@ -29,7 +29,8 @@ class Triodos extends Engine
     {
         $results = [];
         if (preg_match('#:25:TRIODOSBANK/([\d\.]+)#', $this->getCurrentStatementData(), $results)
-            && !empty($results[1])) {
+                && !empty($results[1])
+        ) {
 
             return $this->sanitizeAccount($results[1]);
         }

--- a/src/Parser/Banking/Mt940/Engine/Triodos.php
+++ b/src/Parser/Banking/Mt940/Engine/Triodos.php
@@ -83,23 +83,11 @@ class Triodos extends Engine
      */
     protected function parseTransactionAccountName()
     {
-        $parts = $this->getDescriptionParts();
-        array_shift($parts); // remove BBAN / BIC code
-        if (preg_match('#[A-Z]{2}[0-9]{2}[A-Z]{4}(.*)#', $parts[1], $results)) {
-            array_shift($parts); // remove IBAN too
-            array_shift($parts); // remove IBAN too
-        }
-        array_pop($parts);// remove own account / BBAN
+        $parts = $this->getTransactionAccountParts();
         return $this->sanitizeAccountName(substr(array_shift($parts), 2));
     }
 
-    /**
-     * Crude parsing of the combined iban / non iban description field
-     *
-     * @inheritdoc
-     */
-    protected function parseTransactionDescription()
-    {
+    private function getTransactionAccountParts() {
         $parts = $this->getDescriptionParts();
         array_shift($parts); // remove BBAN / BIC code
         if (preg_match('#[A-Z]{2}[0-9]{2}[A-Z]{4}(.*)#', $parts[1], $results)) {
@@ -108,6 +96,18 @@ class Triodos extends Engine
         }
 
         array_pop($parts);// remove own account / BBAN
+        return $parts;
+    }
+
+
+    /**
+     * Crude parsing of the combined iban / non iban description field
+     *
+     * @inheritdoc
+     */
+    protected function parseTransactionDescription()
+    {
+        $parts = $this->getTransactionAccountParts();
         foreach ($parts as &$part) {
             $part = substr($part, 2);
         }

--- a/test/Banking/StatementTest.php
+++ b/test/Banking/StatementTest.php
@@ -29,8 +29,8 @@ class StatementTest extends \PHPUnit_Framework_TestCase
     public function testTransactionsAssesor()
     {
         $expected = [
-            new Transaction(),
-            new Transaction(),
+                new Transaction(),
+                new Transaction(),
         ];
         $statement = new Statement();
         $statement->setTransactions($expected);
@@ -56,13 +56,30 @@ class StatementTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $statement->getEndPrice());
     }
 
-    public function testTimestampAssesor()
+    /**
+     * @expectedException PHPUnit_Framework_Error_Deprecated
+     * @expectedExceptionMessage Deprecated in favor of splitting the start and end timestamps for a statement. Please use setStartTimestamp($format) or setEndTimestamp($format) instead. setTimestamp is now setStartTimestamp
+     */
+    public function testDeprecatedTimestampAssesor()
     {
         $expected = time();
         $statement = new Statement();
         $statement->setTimestamp($expected);
 
         $this->assertEquals($expected, $statement->getTimestamp());
+    }
+
+    public function testTimestampAssesor()
+    {
+        $time = time();
+        $expectedStart = $time - 1440;
+        $expectedEnd = $time;
+        $statement = new Statement();
+        $statement->setStartTimestamp($expectedStart);
+        $statement->setEndTimestamp($expectedEnd);
+
+        $this->assertEquals($expectedStart, $statement->getStartTimestamp());
+        $this->assertEquals($expectedEnd, $statement->getEndTimestamp());
     }
 
     public function testNumberAssesor()
@@ -95,8 +112,8 @@ class StatementTest extends \PHPUnit_Framework_TestCase
     {
         $statement = new Statement();
         $statement->setTransactions([
-            new Transaction(),
-            new Transaction(),
+                new Transaction(),
+                new Transaction(),
         ]);
         $statement->addTransaction(new Transaction());
 
@@ -105,6 +122,7 @@ class StatementTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @depends testTimestampAssesor
+     * @expectedException PHPUnit_Framework_Error_Deprecated
      */
     public function testGetTimestampWithFormat()
     {
@@ -117,16 +135,16 @@ class StatementTest extends \PHPUnit_Framework_TestCase
 
     public function testJsonSerialization()
     {
-        $expected = '{"bank":"ABN","account":"62.90.64.393","transactions":[],"startPrice":16250,"endPrice":6250,' .
-            '"timestamp":123,"number":"2665487AAF"}';
+        $expected = '{"bank":"ABN","account":"62.90.64.393","transactions":[],' .
+                '"startPrice":16250,"endPrice":6250,"timestamp":0,"startTimestamp":123,"endTimestamp":0,"number":"2665487AAF"}';
         $params = [
-            'bank' => 'ABN',
-            'account' => '62.90.64.393',
-            'transactions' => [],
-            'startPrice' => 16250,
-            'endPrice' => 6250,
-            'timestamp' => 123,
-            'number' => '2665487AAF',
+                'bank' => 'ABN',
+                'account' => '62.90.64.393',
+                'transactions' => [],
+                'startPrice' => 16250,
+                'endPrice' => 6250,
+                'startTimestamp' => 123,
+                'number' => '2665487AAF',
         ];
         $statement = new Statement();
         foreach ($params as $key => $value) {
@@ -137,43 +155,44 @@ class StatementTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @depends testJsonSerialization
+     * @expectedException PHPUnit_Framework_Error_Deprecated
      */
     public function testJsonSerializationWithTransactions()
     {
         $expected = '{"bank":"ABN","account":"62.90.64.393","transactions":[{"account":"123123","accountName":' .
-            '"Kingsquare BV","price":110,"debitcredit":"D","description":"test","valueTimestamp":1231,"entryTimestamp"' .
-            ':1234,"transactionCode":"13G"},{"account":"123123","accountName":"Kingsquare BV","price":110,"debitcredit"' .
-            ':"D","description":"test","valueTimestamp":1231,"entryTimestamp":1234,"transactionCode":"13G"}],' .
-            '"startPrice":16250,"endPrice":6250,"timestamp":123,"number":"2665487AAF"}';
+                '"Kingsquare BV","price":110,"debitcredit":"D","description":"test","valueTimestamp":1231,"entryTimestamp"' .
+                ':1234,"transactionCode":"13G"},{"account":"123123","accountName":"Kingsquare BV","price":110,"debitcredit"' .
+                ':"D","description":"test","valueTimestamp":1231,"entryTimestamp":1234,"transactionCode":"13G"}],' .
+                '"startPrice":16250,"endPrice":6250,"timestamp":123,"number":"2665487AAF"}';
         $params = [
-            'bank' => 'ABN',
-            'account' => '62.90.64.393',
-            'transactions' => [
-                [
-                    'account' => '123123',
-                    'accountName' => 'Kingsquare BV',
-                    'price' => 110.0,
-                    'debitcredit' => Transaction::DEBIT,
-                    'description' => 'test',
-                    'valueTimestamp' => 1231,
-                    'entryTimestamp' => 1234,
-                    'transactionCode' => '13G',
+                'bank' => 'ABN',
+                'account' => '62.90.64.393',
+                'transactions' => [
+                        [
+                                'account' => '123123',
+                                'accountName' => 'Kingsquare BV',
+                                'price' => 110.0,
+                                'debitcredit' => Transaction::DEBIT,
+                                'description' => 'test',
+                                'valueTimestamp' => 1231,
+                                'entryTimestamp' => 1234,
+                                'transactionCode' => '13G',
+                        ],
+                        [
+                                'account' => '123123',
+                                'accountName' => 'Kingsquare BV',
+                                'price' => 110.0,
+                                'debitcredit' => Transaction::DEBIT,
+                                'description' => 'test',
+                                'valueTimestamp' => 1231,
+                                'entryTimestamp' => 1234,
+                                'transactionCode' => '13G',
+                        ],
                 ],
-                [
-                    'account' => '123123',
-                    'accountName' => 'Kingsquare BV',
-                    'price' => 110.0,
-                    'debitcredit' => Transaction::DEBIT,
-                    'description' => 'test',
-                    'valueTimestamp' => 1231,
-                    'entryTimestamp' => 1234,
-                    'transactionCode' => '13G',
-                ],
-            ],
-            'startPrice' => 16250,
-            'endPrice' => 6250,
-            'timestamp' => 123,
-            'number' => '2665487AAF',
+                'startPrice' => 16250,
+                'endPrice' => 6250,
+                'timestamp' => 123,
+                'number' => '2665487AAF',
         ];
         $statement = new Statement();
         foreach ($params as $key => $value) {

--- a/test/Banking/TransactionTest.php
+++ b/test/Banking/TransactionTest.php
@@ -134,17 +134,17 @@ class TransactionTest extends \PHPUnit_Framework_TestCase
     public function testJsonSerialization()
     {
         $expected = '{"account":"123123","accountName":"Kingsquare BV","price":110,"debitcredit":"D",' .
-            '"description":"test","valueTimestamp":1231,"entryTimestamp":1234,"transactionCode":"13G"}';
+                '"description":"test","valueTimestamp":1231,"entryTimestamp":1234,"transactionCode":"13G"}';
 
         $params = [
-            'account' => '123123',
-            'accountName' => 'Kingsquare BV',
-            'price' => 110.0,
-            'debitcredit' => Transaction::DEBIT,
-            'description' => 'test',
-            'valueTimestamp' => 1231,
-            'entryTimestamp' => 1234,
-            'transactionCode' => '13G',
+                'account' => '123123',
+                'accountName' => 'Kingsquare BV',
+                'price' => 110.0,
+                'debitcredit' => Transaction::DEBIT,
+                'description' => 'test',
+                'valueTimestamp' => 1231,
+                'entryTimestamp' => 1234,
+                'transactionCode' => '13G',
         ];
         $statement = new Transaction();
         foreach ($params as $key => $value) {

--- a/test/Parser/Banking/Mt940/Engine/Abn/ParseTest.php
+++ b/test/Parser/Banking/Mt940/Engine/Abn/ParseTest.php
@@ -40,7 +40,7 @@ class ParseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('23-06-2009', $first->getStartTimestamp('d-m-Y'));
         $this->assertEquals('24-06-2009', $first->getEndTimestamp('d-m-Y'));
-        $this->assertEquals('210.5', $first->getDeltaPrice());
+        $this->assertEquals(210.5, $first->getDeltaPrice());
 
         $this->assertEquals('23-06-2009', $last->getStartTimestamp('d-m-Y'));
         $this->assertEquals('24-06-2009', $last->getEndTimestamp('d-m-Y'));

--- a/test/Parser/Banking/Mt940/Engine/Abn/ParseTest.php
+++ b/test/Parser/Banking/Mt940/Engine/Abn/ParseTest.php
@@ -40,7 +40,7 @@ class ParseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('23-06-2009', $first->getStartTimestamp('d-m-Y'));
         $this->assertEquals('24-06-2009', $first->getEndTimestamp('d-m-Y'));
-        $this->assertEquals('210.5', $first->getDeltaPrice(), '', 0.5);
+        $this->assertEquals('210.5', $first->getDeltaPrice());
 
         $this->assertEquals('23-06-2009', $last->getStartTimestamp('d-m-Y'));
         $this->assertEquals('24-06-2009', $last->getEndTimestamp('d-m-Y'));

--- a/test/Parser/Banking/Mt940/Engine/Abn/ParseTest.php
+++ b/test/Parser/Banking/Mt940/Engine/Abn/ParseTest.php
@@ -40,7 +40,7 @@ class ParseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('23-06-2009', $first->getStartTimestamp('d-m-Y'));
         $this->assertEquals('24-06-2009', $first->getEndTimestamp('d-m-Y'));
-        $this->assertEquals('210.5', $first->getDeltaPrice());
+        $this->assertEquals('210.5', $first->getDeltaPrice(), '', 0.5);
 
         $this->assertEquals('23-06-2009', $last->getStartTimestamp('d-m-Y'));
         $this->assertEquals('24-06-2009', $last->getEndTimestamp('d-m-Y'));

--- a/test/Parser/Banking/Mt940/Engine/Abn/ParseTest.php
+++ b/test/Parser/Banking/Mt940/Engine/Abn/ParseTest.php
@@ -29,4 +29,20 @@ class ParseTest extends \PHPUnit_Framework_TestCase
         $method->setAccessible(true);
         $this->assertEquals('ABN', $method->invoke($this->engine));
     }
+
+    public function testParsesAllFoundStatements()
+    {
+        $statements = $this->engine->parse();
+
+        $this->assertEquals(4, count($statements));
+        $first = $statements[0];
+        $last = end($statements);
+
+        $this->assertEquals('23-06-2009', $first->getStartTimestamp('d-m-Y'));
+        $this->assertEquals('24-06-2009', $first->getEndTimestamp('d-m-Y'));
+        $this->assertEquals('210.5', $first->getDeltaPrice());
+
+        $this->assertEquals('23-06-2009', $last->getStartTimestamp('d-m-Y'));
+        $this->assertEquals('24-06-2009', $last->getEndTimestamp('d-m-Y'));
+    }
 }

--- a/test/Parser/Banking/Mt940/Engine/Ing/ParseTest.php
+++ b/test/Parser/Banking/Mt940/Engine/Ing/ParseTest.php
@@ -29,4 +29,17 @@ class ParseTest extends \PHPUnit_Framework_TestCase
         $method->setAccessible(true);
         $this->assertEquals('ING', $method->invoke($this->engine));
     }
+
+    public function testParsesAllFoundStatements()
+    {
+        $statements = $this->engine->parse();
+
+        $this->assertEquals(1, count($statements));
+        $first = $statements[0];
+
+        $this->assertEquals('22-07-2010', $first->getStartTimestamp('d-m-Y'));
+        $this->assertEquals('23-07-2010', $first->getEndTimestamp('d-m-Y'));
+        $this->assertEquals('-3.47', $first->getDeltaPrice());
+    }
+
 }

--- a/test/Parser/Banking/Mt940/Engine/Ing/ParseTest.php
+++ b/test/Parser/Banking/Mt940/Engine/Ing/ParseTest.php
@@ -39,7 +39,7 @@ class ParseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('22-07-2010', $first->getStartTimestamp('d-m-Y'));
         $this->assertEquals('23-07-2010', $first->getEndTimestamp('d-m-Y'));
-        $this->assertEquals('-3.47', $first->getDeltaPrice(), '', 0.5);
+        $this->assertEquals('-3.47', $first->getDeltaPrice());
     }
 
 }

--- a/test/Parser/Banking/Mt940/Engine/Ing/ParseTest.php
+++ b/test/Parser/Banking/Mt940/Engine/Ing/ParseTest.php
@@ -39,7 +39,7 @@ class ParseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('22-07-2010', $first->getStartTimestamp('d-m-Y'));
         $this->assertEquals('23-07-2010', $first->getEndTimestamp('d-m-Y'));
-        $this->assertEquals('-3.47', $first->getDeltaPrice());
+        $this->assertEquals('-3.47', $first->getDeltaPrice(), '', 0.5);
     }
 
 }

--- a/test/Parser/Banking/Mt940/Engine/Ing/ParseTest.php
+++ b/test/Parser/Banking/Mt940/Engine/Ing/ParseTest.php
@@ -39,7 +39,7 @@ class ParseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('22-07-2010', $first->getStartTimestamp('d-m-Y'));
         $this->assertEquals('23-07-2010', $first->getEndTimestamp('d-m-Y'));
-        $this->assertEquals('-3.47', $first->getDeltaPrice());
+        $this->assertEquals(-3.47, $first->getDeltaPrice());
     }
 
 }

--- a/test/Parser/Banking/Mt940/Engine/Rabo/ParseTest.php
+++ b/test/Parser/Banking/Mt940/Engine/Rabo/ParseTest.php
@@ -20,9 +20,6 @@ class ParseTest extends \PHPUnit_Framework_TestCase
         $this->engine->loadString(file_get_contents(__DIR__ . '/sample'));
     }
 
-    /**
-     *
-     */
     public function testParseStatementBank()
     {
         $method = new \ReflectionMethod($this->engine, 'parseStatementBank');
@@ -30,16 +27,32 @@ class ParseTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Rabo', $method->invoke($this->engine));
     }
 
-    public function testParsesAllFoundStatements() {
+    public function testParsesAllFoundStatements()
+    {
         $statements = $this->engine->parse();
+
         $this->assertEquals(39, count($statements));
-        $this->assertEquals('06-01-2003', reset($statements)->getTimestamp('d-m-Y'));
-        $this->assertEquals('08-01-2003', end($statements)->getTimestamp('d-m-Y'));
+        $first = $statements[0];
+        $last = end($statements);
+        $this->assertEquals('06-01-2003', $first->getStartTimestamp('d-m-Y'));
+        $this->assertEquals('07-01-2003', $first->getEndTimestamp('d-m-Y'));
+        $this->assertEquals('08-01-2003', $last->getStartTimestamp('d-m-Y'));
+        $this->assertEquals('09-01-2003', $last->getEndTimestamp('d-m-Y'));
     }
 
-    public function testInitialNegativeStatementBalance() {
+    public function testInitialNegativeStatementBalance()
+    {
         $this->engine->loadString(file_get_contents(__DIR__ . '/sample2'));
         $statements = $this->engine->parse();
         $this->assertEquals(-1000.12, $statements[0]->getStartPrice());
+    }
+
+    public function testCorrectHandlingOfVariousStatementPricing()
+    {
+        $this->engine->loadString(file_get_contents(__DIR__ . '/sample2'));
+        $statements = $this->engine->parse();
+        $this->assertEquals(-1000.12, $statements[0]->getStartPrice());
+        $this->assertEquals(2145.23, $statements[0]->getEndPrice());
+        $this->assertEquals(-3145.35, $statements[0]->getDeltaPrice());
     }
 }

--- a/test/Parser/Banking/Mt940/Engine/Spk/ParseTest.php
+++ b/test/Parser/Banking/Mt940/Engine/Spk/ParseTest.php
@@ -43,4 +43,15 @@ class ParseTest extends \PHPUnit_Framework_TestCase
         }
         $this->assertSame(10, count($tranactions));
     }
+
+    public function testParsesAllFoundStatements()
+    {
+        $statements = $this->engine->parse();
+        $first = $statements[0];
+        $last = end($statements);
+        $this->assertEquals('17-02-2010', $first->getStartTimestamp('d-m-Y'));
+        $this->assertEquals('17-02-2010', $first->getEndTimestamp('d-m-Y'));
+        $this->assertEquals('18-02-2010', $last->getStartTimestamp('d-m-Y'));
+        $this->assertEquals('18-02-2010', $last->getEndTimestamp('d-m-Y'));
+    }
 }

--- a/test/Parser/Banking/Mt940/Engine/Triodos/ParseTest.php
+++ b/test/Parser/Banking/Mt940/Engine/Triodos/ParseTest.php
@@ -79,7 +79,7 @@ class ParseTest extends \PHPUnit_Framework_TestCase
                 '121123',
         ];
         foreach ($this->statements as $i => $statement) {
-            $this->assertSame($known[$i], $statement->getTimestamp('ymd'));
+            $this->assertSame($known[$i], $statement->getStartTimestamp('ymd'));
         }
     }
 
@@ -89,6 +89,22 @@ class ParseTest extends \PHPUnit_Framework_TestCase
         foreach ($this->statements as $i => $statement) {
             $this->assertSame('1', $statement->getNumber());
         }
+    }
+
+    public function testParsesAllFoundStatements()
+    {
+        $statements = $this->statements;
+
+        $first = $statements[0];
+        $last = $statements[1];
+
+        $this->assertEquals('23-11-2012', $first->getStartTimestamp('d-m-Y'));
+        $this->assertEquals('23-11-2012', $first->getEndTimestamp('d-m-Y'));
+        $this->assertEquals('150', $first->getDeltaPrice());
+
+        $this->assertEquals('23-11-2012', $last->getStartTimestamp('d-m-Y'));
+        $this->assertEquals('23-11-2012', $last->getEndTimestamp('d-m-Y'));
+        $this->assertEquals('-59.02', $last->getDeltaPrice());
     }
 
 }

--- a/test/Parser/Banking/Mt940/Engine/Triodos/ParseTest.php
+++ b/test/Parser/Banking/Mt940/Engine/Triodos/ParseTest.php
@@ -104,7 +104,7 @@ class ParseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('23-11-2012', $last->getStartTimestamp('d-m-Y'));
         $this->assertEquals('23-11-2012', $last->getEndTimestamp('d-m-Y'));
-        $this->assertEquals('-59.02', $last->getDeltaPrice(), '', 0.5);
+        $this->assertEquals('-59.02', $last->getDeltaPrice());
     }
 
 }

--- a/test/Parser/Banking/Mt940/Engine/Triodos/ParseTest.php
+++ b/test/Parser/Banking/Mt940/Engine/Triodos/ParseTest.php
@@ -100,11 +100,11 @@ class ParseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('23-11-2012', $first->getStartTimestamp('d-m-Y'));
         $this->assertEquals('23-11-2012', $first->getEndTimestamp('d-m-Y'));
-        $this->assertEquals('150', $first->getDeltaPrice());
+        $this->assertEquals(150, $first->getDeltaPrice());
 
         $this->assertEquals('23-11-2012', $last->getStartTimestamp('d-m-Y'));
         $this->assertEquals('23-11-2012', $last->getEndTimestamp('d-m-Y'));
-        $this->assertEquals('-59.02', $last->getDeltaPrice());
+        $this->assertEquals(-59.02, $last->getDeltaPrice());
     }
 
 }

--- a/test/Parser/Banking/Mt940/Engine/Triodos/ParseTest.php
+++ b/test/Parser/Banking/Mt940/Engine/Triodos/ParseTest.php
@@ -104,7 +104,7 @@ class ParseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('23-11-2012', $last->getStartTimestamp('d-m-Y'));
         $this->assertEquals('23-11-2012', $last->getEndTimestamp('d-m-Y'));
-        $this->assertEquals('-59.02', $last->getDeltaPrice());
+        $this->assertEquals('-59.02', $last->getDeltaPrice(), '', 0.5);
     }
 
 }


### PR DESCRIPTION
This might fullfill the request (#20) to split the timestamps of the statements that might cover more dates. (need sample data to prove this... since all the current sample data is one day only per statement)

This deprecates the Statement::(set|get)Timestamp methods and data

This deprecates the parse method for retrieving the data too.. SPK and the base engine have been upated to reflect this.

All deprecations will now throw deprecation warnings, but still work using the old way: the statement timestamps were interepereted as Start timestamps. Thus if you have code calling the Statement::Timestamp stuff, prepend this with start :D

This if for feature request done in #20