### PR TITLE
made engines open for extension from outside

### DIFF
--- a/src/Parser/Banking/Mt940/Engine/Abn.php
+++ b/src/Parser/Banking/Mt940/Engine/Abn.php
@@ -91,4 +91,14 @@ class Abn extends Engine
 
         return 0;
     }
+
+    /**
+     * Overloaded: Is applicable if first line has ABNA
+     * @inheritdoc
+     */
+    public static function isApplicable($string)
+    {
+        $firstline = strtok($string, "\r\n\t");
+        return strpos($firstline, 'ABNA') !== false;
+    }
 }

--- a/src/Parser/Banking/Mt940/Engine/Ing.php
+++ b/src/Parser/Banking/Mt940/Engine/Ing.php
@@ -120,4 +120,14 @@ class Ing extends Engine
 
         return $description;
     }
+    
+    /**
+     * Overloaded: Is applicable if first line has INGB
+     * @inheritdoc
+     */
+    public static function isApplicable($string)
+    {
+        $firstline = strtok($string, "\r\n\t");
+        return strpos($firstline, 'INGB') !== false;
+    }
 }

--- a/src/Parser/Banking/Mt940/Engine/Rabo.php
+++ b/src/Parser/Banking/Mt940/Engine/Rabo.php
@@ -130,4 +130,14 @@ class Rabo extends Engine
 
         return $description;
     }
+        
+    /**
+     * Overloaded: Is applicable if first line has :940:
+     * @inheritdoc
+     */
+    public static function isApplicable($string)
+    {
+        $firstline = strtok($string, "\r\n\t");
+        return strpos($firstline, ':940:') !== false;
+    }
 }

--- a/src/Parser/Banking/Mt940/Engine/Spk.php
+++ b/src/Parser/Banking/Mt940/Engine/Spk.php
@@ -117,4 +117,15 @@ class Spk extends Engine
                 PREG_SPLIT_NO_EMPTY
         );
     }
+    
+    /**
+     * Overloaded: Is applicable if first or second line has :20:STARTUMS or first line has -
+     * @inheritdoc
+     */
+    public static function isApplicable($string)
+    {
+        $firstline = strtok($string, "\r\n\t");
+        $secondline = strtok("\r\n\t");
+        return (strpos($firstline, ':20:STARTUMS') !== false || $firstline === "-" && $secondline === ':20:STARTUMS');
+    }
 }

--- a/src/Parser/Banking/Mt940/Engine/Triodos.php
+++ b/src/Parser/Banking/Mt940/Engine/Triodos.php
@@ -142,4 +142,14 @@ class Triodos extends Engine
         );
     }
 
+    /**
+     * Overloaded: Is applicable if second line has :25:TRIODOSBANK
+     * @inheritdoc
+     */
+    public static function isApplicable($string)
+    {
+        strtok($string, "\r\n\t");
+        $secondline = strtok("\r\n\t");
+        return (strpos($secondline, ':25:TRIODOSBANK') !== false);
+    }
 }

--- a/test/Parser/Banking/Mt940/Engine/GetInstanceTest.php
+++ b/test/Parser/Banking/Mt940/Engine/GetInstanceTest.php
@@ -38,6 +38,18 @@ class GetInstanceTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider enginesProvider
+     * @param string $engineString
+     * @param string $source
+     */
+    public function testSingleEngine($engineString, $source)
+    {
+        Engine::resetEngines();
+        $engine = @Engine::__getInstance($source);
+        $this->assertInstanceOf('\\Kingsquare\\Parser\\Banking\\Mt940\\Engine\\Unknown', $engine);
+    }
+
+    /**
      * @return array
      */
     public function enginesProvider()


### PR DESCRIPTION
I need to extend the library with an engine, but I am not allowed to do so open source (bank rules). I therefore need a way to inject an engine.

I would have rather added a EngineInterface, and changed the inheritance. A Engine-Implementation does not need to be able to detect a bank, etc. But I opted for a small change instead.

The rules for each engine are now implemented inside of the specific engine class.