### PR TITLE
Add a new "isCancellation" to the transaction and parse it in spk

### DIFF
--- a/src/Banking/Transaction.php
+++ b/src/Banking/Transaction.php
@@ -17,6 +17,7 @@ class Transaction implements \JsonSerializable
     private $accountName = '';
     private $price = 0.0;
     private $debitcredit = '';
+    private $cancellation = false;
     private $description = '';
     private $valueTimestamp = 0;
     private $entryTimestamp = 0;
@@ -60,6 +61,14 @@ class Transaction implements \JsonSerializable
     public function setDebitCredit($var)
     {
         $this->debitcredit = (string) $var;
+    }
+
+    /**
+     * @param bool $var
+     */
+    public function setCancellation($var)
+    {
+        $this->cancellation = (bool) $var;
     }
 
     /**
@@ -177,5 +186,13 @@ class Transaction implements \JsonSerializable
     public function isCredit()
     {
         return $this->getDebitCredit() == self::CREDIT;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isCancellation()
+    {
+        return $this->cancellation;
     }
 }

--- a/src/Parser/Banking/Mt940/Engine.php
+++ b/src/Parser/Banking/Mt940/Engine.php
@@ -147,6 +147,7 @@ abstract class Engine
                 $transaction->setAccountName($this->parseTransactionAccountName());
                 $transaction->setPrice($this->parseTransactionPrice());
                 $transaction->setDebitCredit($this->parseTransactionDebitCredit());
+                $transaction->setCancellation($this->parseTransactionCancellation());
                 $transaction->setDescription($this->parseTransactionDescription());
                 $transaction->setValueTimestamp($this->parseTransactionValueTimestamp());
                 $transaction->setEntryTimestamp($this->parseTransactionEntryTimestamp());
@@ -428,6 +429,15 @@ abstract class Engine
         }
 
         return '';
+    }
+
+    /**
+     * Parses the Cancellation flag of a Transaction
+     *
+     * @return boolean
+     */
+    protected function parseTransactionCancellation () {
+        return false;
     }
 
     /**

--- a/src/Parser/Banking/Mt940/Engine/Spk.php
+++ b/src/Parser/Banking/Mt940/Engine/Spk.php
@@ -98,6 +98,22 @@ class Spk extends Engine
     }
 
     /**
+     * Overloaded: Sparkasse use the Field 61 for cancellations
+     *
+     * {@inheritdoc}
+     */
+    protected function parseTransactionCancellation()
+    {
+        $results = [];
+        if (preg_match('/^:61:\d+(R)?[CD].?\d+/', $this->getCurrentTransactionData(), $results)
+            && !empty($results[1])
+        ) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * Overloaded: Sparkasse does not have a header line.
      *
      * {@inheritdoc}

--- a/test/Banking/TransactionTest.php
+++ b/test/Banking/TransactionTest.php
@@ -131,18 +131,19 @@ class TransactionTest extends \PHPUnit_Framework_TestCase
 
     public function testJsonSerialization()
     {
-        $expected = '{"account":"123123","accountName":"Kingsquare BV","price":110,"debitcredit":"D",'.
-                '"description":"test","valueTimestamp":1231,"entryTimestamp":1234,"transactionCode":"13G"}';
+        $expected = '{"account":"123123","accountName":"Kingsquare BV","price":110,"debitcredit":"D","cancellation":false,'.
+            '"description":"test","valueTimestamp":1231,"entryTimestamp":1234,"transactionCode":"13G"}';
 
         $params = [
-                'account' => '123123',
-                'accountName' => 'Kingsquare BV',
-                'price' => 110.0,
-                'debitcredit' => Transaction::DEBIT,
-                'description' => 'test',
-                'valueTimestamp' => 1231,
-                'entryTimestamp' => 1234,
-                'transactionCode' => '13G',
+            'account' => '123123',
+            'accountName' => 'Kingsquare BV',
+            'price' => 110.0,
+            'debitcredit' => Transaction::DEBIT,
+            'cancellation' => false,
+            'description' => 'test',
+            'valueTimestamp' => 1231,
+            'entryTimestamp' => 1234,
+            'transactionCode' => '13G',
         ];
         $statement = new Transaction();
         foreach ($params as $key => $value) {


### PR DESCRIPTION
We just had the case that we needed the Cancallation flag provided in the Sparkasse file to mark the Cancelled transactions. So i added a possibility to the parser to get this flag.

Since i don't know if that flag exists in other Banks too i set the cancellation flag false by default and only parse it in Sparkasse.