### PR TITLE
Fix #48 for ABNAMRO files using a wrong entry date

### DIFF
--- a/src/Parser/Banking/Mt940/Engine/Abn.php
+++ b/src/Parser/Banking/Mt940/Engine/Abn.php
@@ -78,17 +78,17 @@ class Abn extends Engine
 
     /**
      * Overloaded: ABNAMRO uses the :61: date-part of the field for two values:
-     * Valuetimestamp (YYMMDD) and Entry date (book date) (MMDD).
-     *
+     * Valuetimestamp (YYMMDD) and Entry date (book date) (MMDD). We use the year from the value stamp
+     * and use the date from the entry date, to create the entry date.
      * @return int
      */
     protected function parseTransactionEntryTimestamp()
     {
         $results = [];
-        if (preg_match('/^:61:\d{6}(\d{4})[C|D]/', $this->getCurrentTransactionData(), $results)
-                && !empty($results[1])
+        if (preg_match('/^:61:(\d{2})\d{4}(\d{4})[C|D]/', $this->getCurrentTransactionData(), $results)
+                && !empty($results[1]) && !empty($results[2])
         ) {
-            return $this->sanitizeTimestamp($results[1], 'md');
+            return $this->sanitizeTimestamp($results[1] . $results[2], 'ymd');
         }
 
         return 0;


### PR DESCRIPTION
### Issue
#48 

### What has been done
Edited the regex to use the year of the value stamp and the date of the entry.

### How to test
Import a mt940 ABNAMRO file with bookings from a different year. E.g. bookings from 2013 booked in on 2018 will end up as 2018.