### PR TITLE
Add a getRelativePrice() function to retrieve the price relative to the bank account

### DIFF
--- a/src/Banking/Transaction.php
+++ b/src/Banking/Transaction.php
@@ -129,6 +129,17 @@ class Transaction implements \JsonSerializable
     }
 
     /**
+     * @return float
+     */
+    public function getRelativePrice()
+    {
+        if ($this->isDebit()) {
+            return -$this->price;
+        }
+        return $this->price;
+    }
+
+    /**
      * @return string
      */
     public function getDebitCredit()

--- a/test/Banking/TransactionTest.php
+++ b/test/Banking/TransactionTest.php
@@ -35,6 +35,20 @@ class TransactionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $transaction->getPrice());
     }
 
+    public function testRelativePriceAssesor()
+    {
+        $expected = '6250';
+        $transaction = new Transaction();
+        $transaction->setPrice($expected);
+        $transaction->setDebitCredit('C');
+
+        $this->assertEquals($expected, $transaction->getRelativePrice());
+
+        $transaction->setDebitCredit('D');
+
+        $this->assertEquals($expected * -1, $transaction->getRelativePrice());
+    }
+
     public function testDebitCreditAssesorDebit()
     {
         $expected = 'D';


### PR DESCRIPTION
A lot of times you want to get the relative price, (negative when it is debit or positive when it is credit). A small helper function makes this easier.