### PR TITLE
Readme update & Rabo name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ is transformed into easy to use dataclasses Transaction_banking which itself con
 straight forward.
 
 ## Requirements
-* Atleast the latest supported PHP5. This should read 5.4+, but probably 5.3 would work (and you should upgrade)
+* Atleast PHP 5.5.
 
 ## Installation
 If composer is not yet on your system, follow the instructions on [getcomposer.org](https://getcomposer.org/doc/00-intro.md#installation-linux-unix-osx) to do so.

--- a/src/Parser/Banking/Mt940/Engine/Rabo.php
+++ b/src/Parser/Banking/Mt940/Engine/Rabo.php
@@ -74,6 +74,12 @@ class Rabo extends Engine
                 return $this->sanitizeAccountName($accountName);
             }
         }
+        
+        if (preg_match('#/NAME/(.+?)/#ms',$this->getCurrentTransactionData(), $results)) // Last chance test to see if we get something from the AM04 or something
+        {
+          $accountName = trim($results[1]);
+          return $this->sanitizeAccountName($accountName);
+        }
         return '';
     }
 


### PR DESCRIPTION
Same readme update as previous PR, which was closed ;-).

It seems the Rabo parser doesn't support the following syntax:
:86:/MARF/blah/EREF/blah2/RTRN/AM04/BENM//NAME/LoremIpsum/
I've added fallback support so this can work. I doubt this is the best way, but it works for me.

Due to the fact, I need to know the RTRN codes, I've started using the raw data now, as I cannot fit this quickly into the current structure. But that's not an issue here.