### PR TITLE
Read account number in addition to bank number for german Sparkasse

### DIFF
--- a/src/Parser/Banking/Mt940/Engine/Spk.php
+++ b/src/Parser/Banking/Mt940/Engine/Spk.php
@@ -23,6 +23,23 @@ class Spk extends Engine
     }
 
     /**
+     * Overloaded: the bankaccount may be "BLZ/Account".
+     *
+     * @inheritdoc
+     */
+    protected function parseStatementAccount()
+    {
+        $results = [];
+        if (preg_match('#:25:(\d{8}/\d+)#', $this->getCurrentStatementData(), $results)
+            && !empty($results[1])
+        ) {
+            return $this->sanitizeAccount($results[1]);
+        }
+
+        return parent::parseStatementAccount();
+    }
+
+    /**
      * Overloaded: Sparkasse uses 60M and 60F.
      *
      * @inheritdoc


### PR DESCRIPTION
My german Sparkasse has ":25:XXXXXXXX/YYYYYYYYY", where XXXXXXXX is the number of the bank (always 8 digits for german banks) and YYYYYYYYY the number of the account at that bank. The current parsing in Engine::parseStatementAccount() results in having only XXXXXXXX.
This pull request adds a overloaded Spk::parseStatementAccount() to fix that.