### PR TITLE
Add return types for jsonSerialize

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   ],
   "require": {
-    "php": ">=7",
+    "php": ">=8",
     "ext-json": "*"
   },
   "require-dev": {

--- a/src/Banking/Statement.php
+++ b/src/Banking/Statement.php
@@ -23,7 +23,7 @@ class Statement implements \JsonSerializable
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return get_object_vars($this);
     }

--- a/src/Banking/Transaction.php
+++ b/src/Banking/Transaction.php
@@ -26,7 +26,7 @@ class Transaction implements \JsonSerializable
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return get_object_vars($this);
     }

--- a/src/Parser/Banking/Mt940.php
+++ b/src/Parser/Banking/Mt940.php
@@ -20,11 +20,11 @@ class Mt940 extends Banking
      * Parse the given string into an array of Banking\Statement objects.
      *
      * @param string $string
-     * @param Banking\Mt940\Engine $engine
+     * @param ?Banking\Mt940\Engine $engine
      *
      * @return \Kingsquare\Banking\Statement[]
      */
-    public function parse($string, Banking\Mt940\Engine $engine = null)
+    public function parse($string, ?Banking\Mt940\Engine $engine = null)
     {
         if (!empty($string)) {
             // load engine


### PR DESCRIPTION
Refs #91 

Php 8 deprecations fixed. 

I updated the composer to have php8 as minimum. 
Php8.0 has no maintenance anymore (see https://endoflife.date/php), so we might want to bump that up to 8.1 even for a new major release of this package. 

Let me know what else is needed. 
